### PR TITLE
Update scrape.py

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -468,7 +468,7 @@ def add_linux_ami_info(instances):
     checkmark_char = u'\u2713'
     url = "http://aws.amazon.com/amazon-linux-ami/instance-type-matrix/"
     tree = etree.parse(urllib2.urlopen(url), etree.HTMLParser())
-    table = tree.xpath('//div[@class="aws-table "]/table')[0]
+    table = tree.xpath('//div[@class="aws-table"]/table')[0]
     rows = table.xpath('.//tr[./td]')[1:]  # ignore header
 
     for r in rows:


### PR DESCRIPTION
removed the space after "aws-table " on line 471 ( table = tree.xpath('//div[@class="aws-table"]/table')[0] )